### PR TITLE
Added ability to enable/disable the undo feature

### DIFF
--- a/Include/global_variables.h
+++ b/Include/global_variables.h
@@ -394,4 +394,6 @@ START_GLOBALS
     DEF_GLOBAL( Selected_box_y_offset, Real, 2.0 )
     DEF_GLOBAL( Tags_from_label, BOOLEAN, FALSE )
 
+	DEF_GLOBAL( Initial_undo_feature, BOOLEAN, TRUE )
+
 END_GLOBALS

--- a/Include/slice.h
+++ b/Include/slice.h
@@ -161,6 +161,8 @@ typedef  struct
     loaded_volume_struct   *volumes;
     int                    current_volume_index;
 
+    BOOLEAN                toggle_undo_feature;
+
     BOOLEAN                crop_labels_on_output_flag;
     BOOLEAN                share_labels_flag;
     colour_bar_struct      colour_bar;

--- a/callbacks/regions.c
+++ b/callbacks/regions.c
@@ -699,7 +699,12 @@ public  DEF_MENU_FUNCTION( undo_slice_labels )
 
 public  DEF_MENU_UPDATE(undo_slice_labels )
 {
-    return( slice_labels_to_undo(display) );
+    display_struct   *slice_window;
+
+    get_slice_window( display, &slice_window );
+
+    return( slice_window->slice.toggle_undo_feature && 
+			slice_labels_to_undo(display) );
 }
 
 /* ARGSUSED */

--- a/callbacks/segmenting.c
+++ b/callbacks/segmenting.c
@@ -33,6 +33,41 @@ private  void   set_connected_labels(
 
 /* ARGSUSED */
 
+public  DEF_MENU_FUNCTION( toggle_undo_feature )
+{
+    display_struct   *slice_window;
+
+    if( get_slice_window( display, &slice_window) && 
+            ! (slice_window->slice.toggle_undo_feature =
+                !slice_window->slice.toggle_undo_feature) )
+    {
+        delete_slice_undo( &slice_window->slice.undo, -1 );
+    }
+
+    return( OK );
+}
+
+/* ARGSUSED */
+
+public  DEF_MENU_UPDATE( toggle_undo_feature )
+{
+    BOOLEAN          state, set;
+    display_struct   *slice_window;
+
+    state = get_slice_window( display, &slice_window );
+
+    if( state )
+        set = slice_window->slice.toggle_undo_feature;
+    else
+        set = Initial_undo_feature;
+
+    set_menu_text_on_off( menu_window, menu_entry, set );
+
+    return( state );
+}
+
+/* ARGSUSED */
+
 public  DEF_MENU_FUNCTION( label_voxel )
 {
     Real           voxel[MAX_DIMENSIONS];

--- a/menu/Display.menu.base
+++ b/menu/Display.menu.base
@@ -369,6 +369,7 @@ segmenting \
     transient 'v'    calculate_volume                 'Calculate Volume' \
     transient 'b'    toggle_display_labels           'Show Labels: %s' \
     transient 'n'    copy_labels_from_lower_slice  'Copy from Lt/Inf/Post Slice' \
+    transient 'm'    toggle_undo_feature              'Enable Undo: %s' \
  \
     transient '1'    set_current_erase_label          'Set Erase Lbl: %d' \
     transient '2'    toggle_fast_update               'Fast Update: %s' \

--- a/menu/Display.menu.include
+++ b/menu/Display.menu.include
@@ -368,6 +368,7 @@ segmenting \
     transient 'v'    calculate_volume                 'Calculate Volume' \
     transient 'b'    toggle_display_labels           'Show Labels: %s' \
     transient 'n'    copy_labels_from_lower_slice  'Copy from Lt/Inf/Post Slice' \
+    transient 'm'    toggle_undo_feature              'Enable Undo: %s' \
  \
     transient '1'    set_current_erase_label          'Set Erase Lbl: %d' \
     transient '2'    toggle_fast_update               'Fast Update: %s' \

--- a/menu/input_menu.c
+++ b/menu/input_menu.c
@@ -226,6 +226,7 @@ MENU_F(translate_labels_right) \
 MENU_F(translate_labels_arbitrary)
 
 #define  MENU4 \
+MENU_F(toggle_undo_feature) \
 MENU_F(calculate_volume) \
 MENU_F(toggle_current_volume) \
 MENU_F(delete_current_volume) \

--- a/segmenting/painting.c
+++ b/segmenting/painting.c
@@ -222,7 +222,9 @@ private  DEF_EVENT_FUNCTION( right_mouse_down )
     slice_window->slice.segmenting.x_mouse_start = x_pixel;
     slice_window->slice.segmenting.y_mouse_start = y_pixel;
 
-    record_slice_under_mouse( slice_window, volume_index );
+    if ( slice_window->slice.toggle_undo_feature ){
+        record_slice_under_mouse( slice_window, volume_index );
+    }
 
     if( is_shift_key_pressed() )
         label = slice_window->slice.current_erase_label;

--- a/segmenting/painting_new.c
+++ b/segmenting/painting_new.c
@@ -147,7 +147,9 @@ private  DEF_EVENT_FUNCTION( right_mouse_down )
     slice_window->slice.segmenting.x_mouse_start = x_pixel;
     slice_window->slice.segmenting.y_mouse_start = y_pixel;
 
-    record_slice_under_mouse( slice_window, volume_index );
+    if ( slice_window->slice.toggle_undo_feature ){
+        record_slice_under_mouse( slice_window, volume_index );
+    }
 
     if( is_shift_key_pressed( slice_window ) )
         label = slice_window->slice.current_erase_label;

--- a/slice_window/slice.c
+++ b/slice_window/slice.c
@@ -126,6 +126,8 @@ private  void  initialize_slice_window(
     slice_window->slice.current_paint_label = Default_paint_label;
     slice_window->slice.current_erase_label = 0;
 
+    slice_window->slice.toggle_undo_feature = Initial_undo_feature;
+
     set_atlas_state( slice_window, Default_atlas_state );
 
     initialize_slice_undo( &slice_window->slice.undo );


### PR DESCRIPTION
Painting can be slow on big images due to the way the undo feature is implemented. This change lets the user set the availability of the undo feature from 'Initial_undo_feature' in Display.globals, or toggle it from 'm' in the segmenting menu.
